### PR TITLE
Add `useGet` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,23 +1,17 @@
 const http = require('http');
 
-module.exports = (port, options) => {
-	if (typeof port === 'object') {
-		options = port;
-		port = 80;
-	}
-
+module.exports = options => {
 	options = {
-		method: 'HEAD',
 		...options
 	};
 
 	return new Promise(resolve => {
 		const retry = () => setTimeout(main, 200);
 
-		const method = options.method.toUpperCase();
+		const method = options.useGet ? 'GET' : 'HEAD';
 
 		const main = () => {
-			const request = http.request({method, port}, response => {
+			const request = http.request({method, port: options.port}, response => {
 				if (response.statusCode === 200) {
 					return resolve();
 				}

--- a/index.js
+++ b/index.js
@@ -1,11 +1,23 @@
 const http = require('http');
 
-module.exports = port =>
-	new Promise(resolve => {
-		const retry = () => setTimeout(main, 200); // eslint-disable-line no-use-before-define
+module.exports = (port, options) => {
+	if (typeof port === 'object') {
+		options = port;
+		port = 80;
+	}
+
+	options = {
+		method: 'HEAD',
+		...options
+	};
+
+	return new Promise(resolve => {
+		const retry = () => setTimeout(main, 200);
+
+		const method = options.method.toUpperCase();
 
 		const main = () => {
-			const request = http.request({method: 'HEAD', port}, response => {
+			const request = http.request({method, port}, response => {
 				if (response.statusCode === 200) {
 					return resolve();
 				}
@@ -19,3 +31,4 @@ module.exports = port =>
 
 		main();
 	});
+};

--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 const http = require('http');
 
 module.exports = options => {
-	options = {
-		...options
-	};
+	options = Object.assign({}, options);
 
 	return new Promise(resolve => {
 		const retry = () => setTimeout(main, 200);

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ const waitForLocalhost = require('wait-for-localhost');
 
 ## API
 
-### waitForLocalHost([port])
+### waitForLocalHost([port], [options])
 
 Returns a `Promise` that settles when localhost is ready.
 
@@ -34,6 +34,13 @@ Returns a `Promise` that settles when localhost is ready.
 
 Type: `number`<br>
 Default: `80`
+
+#### options
+
+##### method
+
+Type: `string`<br>
+Default: `HEAD`
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -26,21 +26,25 @@ const waitForLocalhost = require('wait-for-localhost');
 
 ## API
 
-### waitForLocalHost([port], [options])
+### waitForLocalHost([options])
 
 Returns a `Promise` that settles when localhost is ready.
 
-#### port
+#### options
+
+Type: `object`
+
+##### port
 
 Type: `number`<br>
 Default: `80`
 
-#### options
-
-##### method
+##### useGet
 
 Type: `string`<br>
-Default: `HEAD`
+Default: `false`
+
+Use the `GET` http-method to check if the server is running, otherwise use `HEAD`.
 
 
 ## Related

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Returns a `Promise` that settles when localhost is ready.
 
 #### options
 
-Type: `object`
+Type: `Object`
 
 ##### port
 
@@ -44,7 +44,7 @@ Default: `80`
 Type: `string`<br>
 Default: `false`
 
-Use the `GET` http-method to check if the server is running, otherwise use `HEAD`.
+Use the `GET` HTTP-method instead of `HEAD` to check if the server is running.
 
 
 ## Related

--- a/test.js
+++ b/test.js
@@ -13,7 +13,7 @@ test('main', async t => {
 		t.pass();
 	});
 
-	await waitForLocalhost(server.port);
+	await waitForLocalhost({port: server.port});
 
 	t.pass();
 
@@ -30,8 +30,9 @@ test('use get method', async t => {
 		t.pass();
 	});
 
-	await waitForLocalhost(server.port, {
-		method: 'get'
+	await waitForLocalhost({
+		port: server.port,
+		useGet: true
 	});
 
 	t.pass();

--- a/test.js
+++ b/test.js
@@ -19,3 +19,22 @@ test('main', async t => {
 
 	await server.close();
 });
+
+test('use get method', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		await delay(1000);
+		response.end();
+		t.pass();
+	});
+
+	await waitForLocalhost(server.port, {
+		method: 'get'
+	});
+
+	t.pass();
+
+	await server.close();
+});


### PR DESCRIPTION
Because `webpack-dev-server` doesn't reply to `HEAD`, we need a way to specify `GET` as used http-method. This PR allows that.

Will add a PR for `wait-for-localhost-cli` as  well.