### PR TITLE
feat: Wait for localhost in IPv4 and IPv6

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,4 +32,4 @@ await waitForLocalhost({port: 8080});
 console.log('Server is ready');
 ```
 */
-export default function waitForLocalhost(options?: Options): Promise<{family: 4|6}>;
+export default function waitForLocalhost(options?: Options): Promise<{ipVersion: 4 | 6}>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,4 +32,4 @@ await waitForLocalhost({port: 8080});
 console.log('Server is ready');
 ```
 */
-export default function waitForLocalhost(options?: Options): Promise<void>;
+export default function waitForLocalhost(options?: Options): Promise<{family: 4|6}>;

--- a/index.js
+++ b/index.js
@@ -8,18 +8,26 @@ export default function waitForLocalhost({port, path, useGet} = {}) {
 
 		const method = useGet ? 'GET' : 'HEAD';
 
-		const main = () => {
-			const request = http.request({method, port, path}, response => {
+		const doRequest = (family, next) => {
+			const request = http.request({method, port, path, family}, response => {
 				if (response.statusCode === 200) {
-					resolve();
+					resolve({family});
 					return;
 				}
 
-				retry();
+				next();
 			});
 
-			request.on('error', retry);
+			request.on('error', next);
 			request.end();
+		};
+
+		const main = () => {
+			doRequest(4,
+				() => doRequest(6,
+					() => retry(),
+				),
+			);
 		};
 
 		main();

--- a/index.js
+++ b/index.js
@@ -8,10 +8,10 @@ export default function waitForLocalhost({port, path, useGet} = {}) {
 
 		const method = useGet ? 'GET' : 'HEAD';
 
-		const doRequest = (family, next) => {
-			const request = http.request({method, port, path, family}, response => {
+		const doRequest = (ipVersion, next) => {
+			const request = http.request({method, port, path, family: ipVersion}, response => {
 				if (response.statusCode === 200) {
-					resolve({family});
+					resolve({ipVersion});
 					return;
 				}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd';
 import waitForLocalhost from './index.js';
 
-expectType<Promise<void>>(waitForLocalhost());
-expectType<Promise<void>>(waitForLocalhost({port: 8080}));
-expectType<Promise<void>>(waitForLocalhost({path: '/health'}));
-expectType<Promise<void>>(waitForLocalhost({useGet: true}));
+expectType<Promise<{family: 4|6}>>(waitForLocalhost());
+expectType<Promise<{family: 4|6}>>(waitForLocalhost({port: 8080}));
+expectType<Promise<{family: 4|6}>>(waitForLocalhost({path: '/health'}));
+expectType<Promise<{family: 4|6}>>(waitForLocalhost({useGet: true}));

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd';
 import waitForLocalhost from './index.js';
 
-expectType<Promise<{family: 4|6}>>(waitForLocalhost());
-expectType<Promise<{family: 4|6}>>(waitForLocalhost({port: 8080}));
-expectType<Promise<{family: 4|6}>>(waitForLocalhost({path: '/health'}));
-expectType<Promise<{family: 4|6}>>(waitForLocalhost({useGet: true}));
+expectType<Promise<{ipVersion: 4 | 6}>>(waitForLocalhost());
+expectType<Promise<{ipVersion: 4 | 6}>>(waitForLocalhost({port: 8080}));
+expectType<Promise<{ipVersion: 4 | 6}>>(waitForLocalhost({path: '/health'}));
+expectType<Promise<{ipVersion: 4 | 6}>>(waitForLocalhost({useGet: true}));


### PR DESCRIPTION
Unfortunately, node 17 and newer have no deterministic behavior anymore when resolving [hostnames](https://github.com/nodejs/node/issues/40537).
This means a server could be started at `127.0.0.1:8080`, but then `wait-for-localhost` resolves `localhost` to `::1`, and ends up waiting forever.

This change tries both IPv4 and IPv6 and also returns which IP version it succeded on.

Let me know what you think about this.

I didn't add tests yet, because `create-test-server` does not allow to specify the IP version.