### PR TITLE
Support different HTTP status codes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export interface Options {
 	useGet?: boolean;
 
 	/**
-	HTTP status codes to consider as successful response.
+	HTTP status codes to consider as successful responses.
 
 	@default [200]
 	*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,13 @@ export interface Options {
 	@default false
 	*/
 	useGet?: boolean;
+
+	/**
+	HTTP status code to consider as successful response
+
+	@default 200
+	*/
+	statusCode?: number | number[];
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,11 +21,11 @@ export interface Options {
 	useGet?: boolean;
 
 	/**
-	HTTP status code to consider as successful response
+	HTTP status codes to consider as successful response.
 
-	@default 200
+	@default [200]
 	*/
-	statusCode?: number | number[];
+	statusCodes?: number[];
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export interface Options {
 
 	@default [200]
 	*/
-	statusCodes?: number[];
+	statusCodes?: readonly number[];
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -1,17 +1,16 @@
 import http from 'node:http';
 
-export default function waitForLocalhost({port, path, useGet, statusCode = 200} = {}) {
+export default function waitForLocalhost({port, path, useGet, statusCodes = [200]} = {}) {
 	return new Promise(resolve => {
 		const retry = () => {
 			setTimeout(main, 200);
 		};
 
 		const method = useGet ? 'GET' : 'HEAD';
-		const validStatusCodes = Array.isArray(statusCode) ? statusCode : [statusCode];
 
 		const doRequest = (ipVersion, next) => {
 			const request = http.request({method, port, path, family: ipVersion}, response => {
-				if (validStatusCodes.includes(response.statusCode)) {
+				if (statusCodes.includes(response.statusCode)) {
 					resolve({ipVersion});
 					return;
 				}

--- a/index.js
+++ b/index.js
@@ -1,16 +1,17 @@
 import http from 'node:http';
 
-export default function waitForLocalhost({port, path, useGet} = {}) {
+export default function waitForLocalhost({port, path, useGet, statusCode = 200} = {}) {
 	return new Promise(resolve => {
 		const retry = () => {
 			setTimeout(main, 200);
 		};
 
 		const method = useGet ? 'GET' : 'HEAD';
+		const validStatusCodes = Array.isArray(statusCode) ? statusCode : [statusCode];
 
 		const doRequest = (ipVersion, next) => {
 			const request = http.request({method, port, path, family: ipVersion}, response => {
-				if (response.statusCode === 200) {
+				if (validStatusCodes.includes(response.statusCode)) {
 					resolve({ipVersion});
 					return;
 				}

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Use the `GET` HTTP-method instead of `HEAD` to check if the server is running.
 Type: `number[]`\
 Default: `[200]`
 
-HTTP status codes to consider as successful response.
+HTTP status codes to consider as successful responses.
 
 ## Related
 

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,13 @@ Default: `false`
 
 Use the `GET` HTTP-method instead of `HEAD` to check if the server is running.
 
+##### statusCode
+
+Type: `number | number[]`\
+Default: `200`
+
+Define one or multiple HTTP status codes indicating the server is ready.
+
 ## Related
 
 - [wait-for-localhost-cli](https://github.com/sindresorhus/wait-for-localhost-cli) - CLI for this module

--- a/readme.md
+++ b/readme.md
@@ -52,12 +52,12 @@ Default: `false`
 
 Use the `GET` HTTP-method instead of `HEAD` to check if the server is running.
 
-##### statusCode
+##### statusCodes
 
-Type: `number | number[]`\
-Default: `200`
+Type: `number[]`\
+Default: `[200]`
 
-Define one or multiple HTTP status codes indicating the server is ready.
+HTTP status codes to consider as successful response.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -99,4 +99,3 @@ test('use custom statusCode list', async t => {
 
 	await server.close();
 });
-

--- a/test.js
+++ b/test.js
@@ -60,27 +60,7 @@ test('use custom path', async t => {
 	await server.close();
 });
 
-test('use custom statusCode', async t => {
-	t.plan(2);
-
-	const server = await createTestServer();
-	server.get('/', async (request, response) => {
-		await delay(1000);
-		response.status(201).end();
-		t.pass();
-	});
-
-	await waitForLocalhost({
-		port: server.port,
-		statusCode: 201,
-	});
-
-	t.pass();
-
-	await server.close();
-});
-
-test('use custom statusCode list', async t => {
+test('use custom statusCodes', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
@@ -92,7 +72,7 @@ test('use custom statusCode list', async t => {
 
 	await waitForLocalhost({
 		port: server.port,
-		statusCode: [201, 202],
+		statusCodes: [201, 202],
 	});
 
 	t.pass();

--- a/test.js
+++ b/test.js
@@ -59,3 +59,44 @@ test('use custom path', async t => {
 
 	await server.close();
 });
+
+test('use custom statusCode', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		await delay(1000);
+		response.status(201).end();
+		t.pass();
+	});
+
+	await waitForLocalhost({
+		port: server.port,
+		statusCode: 201,
+	});
+
+	t.pass();
+
+	await server.close();
+});
+
+test('use custom statusCode list', async t => {
+	t.plan(2);
+
+	const server = await createTestServer();
+	server.get('/', async (request, response) => {
+		await delay(1000);
+		response.status(202).end();
+		t.pass();
+	});
+
+	await waitForLocalhost({
+		port: server.port,
+		statusCode: [201, 202],
+	});
+
+	t.pass();
+
+	await server.close();
+});
+


### PR DESCRIPTION
Allow the user to specify the HTTP status codes considered as succesful response.

Currently the server has to respond with `200` to pass the check. With this change the user can specify one or multiple HTTP status codes to pass the check.