### PR TITLE
fix: endless loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,102 @@
-import http from 'node:http';
-import http2 from 'node:http2';
+import http from "node:http";
+import http2 from "node:http2";
 
 const RETRY_DELAY = 200;
 const HTTP1_ATTEMPTS = 6; // 3 rounds × 2 IP versions
 
-export default function waitForLocalhost({port = 80, path = '/', useGet, statusCodes = [200], signal} = {}) {
+const tryHttp1 = (
+	ipVersion,
+	onError,
+	method,
+	port,
+	path,
+	signal,
+	handleResponse,
+) => {
+	const request = http.request(
+		{
+			method,
+			port,
+			path,
+			family: ipVersion,
+			signal,
+		},
+		(response) => {
+			handleResponse(response.statusCode, ipVersion, onError);
+		},
+	);
+
+	request.on("error", onError);
+	request.end();
+};
+
+const noop = () => {};
+
+const tryHttp2 = (
+	ipVersion,
+	onError,
+	method,
+	port,
+	path,
+	signal,
+	handleResponse,
+) => {
+	const hostname = ipVersion === 6 ? "[::1]" : "localhost";
+	const client = http2.connect(`http://${hostname}:${port}`);
+
+	const cleanup = () => {
+		signal?.removeEventListener("abort", cleanup, { once: true });
+		client.off("error", handleClientError);
+		request.off("response", handleRequestResponse);
+		request.off("error", handleRequestError);
+		client.on("error", noop);
+		request.on("error", noop);
+		if (!client.destroyed) {
+			client.destroy();
+		}
+	};
+
+	// Cleanup on abort
+	signal?.addEventListener("abort", cleanup, { once: true });
+
+	const handleClientError = () => {
+		cleanup();
+		onError();
+	};
+
+	client.on("error", handleClientError);
+
+	const request = client.request({
+		":method": method,
+		":path": path,
+	});
+
+	const handleRequestResponse = (headers) => {
+		cleanup();
+		handleResponse(headers[":status"], ipVersion, onError);
+	};
+
+	request.on("response", handleRequestResponse);
+
+	const handleRequestError = () => {
+		cleanup();
+		onError();
+	};
+	request.on("error", handleRequestError);
+
+	request.end();
+};
+
+export default function waitForLocalhost({
+	port = 80,
+	path = "/",
+	useGet,
+	statusCodes = [200],
+	signal,
+} = {}) {
 	return new Promise((resolve, reject) => {
 		let attemptCount = 0;
-		const method = useGet ? 'GET' : 'HEAD';
+		const method = useGet ? "GET" : "HEAD";
 		let retryTimeout;
 
 		if (signal?.aborted) {
@@ -21,74 +110,35 @@ export default function waitForLocalhost({port = 80, path = '/', useGet, statusC
 			}
 		};
 
-		signal?.addEventListener('abort', () => {
-			cleanup();
-			reject(signal.reason);
-		}, {once: true});
+		signal?.addEventListener(
+			"abort",
+			() => {
+				cleanup();
+				reject(signal.reason);
+			},
+			{ once: true },
+		);
 
 		const handleResponse = (statusCode, ipVersion, onError) => {
 			if (statusCodes.includes(statusCode)) {
-				resolve({ipVersion});
+				resolve({ ipVersion });
 			} else {
 				onError();
 			}
 		};
 
-		const tryHttp1 = (ipVersion, onError) => {
-			const request = http.request({
-				method,
-				port,
-				path,
-				family: ipVersion,
-				signal,
-			}, response => {
-				handleResponse(response.statusCode, ipVersion, onError);
-			});
-
-			request.on('error', onError);
-			request.end();
-		};
-
-		const tryHttp2 = (ipVersion, onError) => {
-			const hostname = ipVersion === 6 ? '[::1]' : 'localhost';
-			const client = http2.connect(`http://${hostname}:${port}`);
-
-			const cleanupClient = () => {
-				if (!client.destroyed) {
-					client.destroy();
-				}
-			};
-
-			// Cleanup on abort
-			signal?.addEventListener('abort', cleanupClient, {once: true});
-
-			client.on('error', () => {
-				cleanupClient();
-				onError();
-			});
-
-			const request = client.request({
-				':method': method,
-				':path': path,
-			});
-
-			request.on('response', headers => {
-				cleanupClient();
-				handleResponse(headers[':status'], ipVersion, onError);
-			});
-
-			request.on('error', () => {
-				cleanupClient();
-				onError();
-			});
-
-			request.end();
-		};
-
 		const tryRequest = (ipVersion, onError) => {
 			const useHttp2 = attemptCount > HTTP1_ATTEMPTS;
 			const requestFunction = useHttp2 ? tryHttp2 : tryHttp1;
-			requestFunction(ipVersion, onError);
+			requestFunction(
+				ipVersion,
+				onError,
+				method,
+				port,
+				path,
+				signal,
+				handleResponse,
+			);
 		};
 
 		const retry = () => {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import http2 from 'node:http2';
 const RETRY_DELAY = 200;
 const HTTP1_ATTEMPTS = 6; // 3 rounds × 2 IP versions
 
-const tryHttp1 = (
+const tryHttp1 = ({
 	ipVersion,
 	onError,
 	method,
@@ -12,7 +12,7 @@ const tryHttp1 = (
 	path,
 	signal,
 	handleResponse,
-) => {
+}) => {
 	const request = http.request(
 		{
 			method,
@@ -32,7 +32,7 @@ const tryHttp1 = (
 
 const noop = () => {};
 
-const tryHttp2 = (
+const tryHttp2 = ({
 	ipVersion,
 	onError,
 	method,
@@ -40,7 +40,7 @@ const tryHttp2 = (
 	path,
 	signal,
 	handleResponse,
-) => {
+}) => {
 	const hostname = ipVersion === 6 ? '[::1]' : 'localhost';
 	const client = http2.connect(`http://${hostname}:${port}`);
 
@@ -131,7 +131,7 @@ export default function waitForLocalhost({
 		const tryRequest = (ipVersion, onError) => {
 			const useHttp2 = attemptCount > HTTP1_ATTEMPTS;
 			const requestFunction = useHttp2 ? tryHttp2 : tryHttp1;
-			requestFunction(
+			requestFunction({
 				ipVersion,
 				onError,
 				method,
@@ -139,7 +139,7 @@ export default function waitForLocalhost({
 				path,
 				signal,
 				handleResponse,
-			);
+			});
 		};
 
 		const retry = () => {

--- a/test.js
+++ b/test.js
@@ -186,6 +186,7 @@ test("should support AbortSignal.timeout()", async (t) => {
 });
 
 test("should not loop on error", async (t) => {
+	t.timeout(40_000);
 	try {
 		await waitForLocalhost({
 			port: 5879,

--- a/test.js
+++ b/test.js
@@ -1,32 +1,32 @@
-import { promisify } from "node:util";
-import http2 from "node:http2";
-import test from "ava";
-import delay from "delay";
-import createTestServer from "create-test-server";
-import waitForLocalhost from "./index.js";
+import {promisify} from 'node:util';
+import http2 from 'node:http2';
+import test from 'ava';
+import delay from 'delay';
+import createTestServer from 'create-test-server';
+import waitForLocalhost from './index.js';
 
-test("main", async (t) => {
+test('main', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.head("/", async (request, response) => {
+	server.head('/', async (request, response) => {
 		await delay(1000);
 		response.end();
 		t.pass();
 	});
 
-	await waitForLocalhost({ port: server.port });
+	await waitForLocalhost({port: server.port});
 
 	t.pass();
 
 	await server.close();
 });
 
-test("use get method", async (t) => {
+test('use get method', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.get("/", async (request, response) => {
+	server.get('/', async (request, response) => {
 		await delay(1000);
 		response.end();
 		t.pass();
@@ -42,11 +42,11 @@ test("use get method", async (t) => {
 	await server.close();
 });
 
-test("use custom path", async (t) => {
+test('use custom path', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.get("/health", async (request, response) => {
+	server.get('/health', async (request, response) => {
 		await delay(1000);
 		response.end();
 		t.pass();
@@ -54,7 +54,7 @@ test("use custom path", async (t) => {
 
 	await waitForLocalhost({
 		port: server.port,
-		path: "/health",
+		path: '/health',
 	});
 
 	t.pass();
@@ -62,11 +62,11 @@ test("use custom path", async (t) => {
 	await server.close();
 });
 
-test("use custom statusCodes", async (t) => {
+test('use custom statusCodes', async t => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.get("/", async (request, response) => {
+	server.get('/', async (request, response) => {
 		await delay(1000);
 		response.status(202).end();
 		t.pass();
@@ -82,38 +82,38 @@ test("use custom statusCodes", async (t) => {
 	await server.close();
 });
 
-test("should handle HTTP/2-only server with fallback", async (t) => {
+test('should handle HTTP/2-only server with fallback', async t => {
 	const server = http2.createServer();
 
-	server.on("stream", (stream, headers) => {
-		if (headers[":method"] === "HEAD") {
-			stream.respond({ ":status": 200 });
+	server.on('stream', (stream, headers) => {
+		if (headers[':method'] === 'HEAD') {
+			stream.respond({':status': 200});
 			stream.end();
 		}
 	});
 
 	await promisify(server.listen.bind(server))(0);
-	const { port } = server.address();
+	const {port} = server.address();
 
-	const result = await waitForLocalhost({ port });
+	const result = await waitForLocalhost({port});
 	t.truthy(result);
 	t.true([4, 6].includes(result.ipVersion));
 
 	server.close();
 });
 
-test("should handle HTTP/2-only server with custom status codes", async (t) => {
+test('should handle HTTP/2-only server with custom status codes', async t => {
 	const server = http2.createServer();
 
-	server.on("stream", (stream, headers) => {
-		if (headers[":method"] === "HEAD") {
-			stream.respond({ ":status": 202 });
+	server.on('stream', (stream, headers) => {
+		if (headers[':method'] === 'HEAD') {
+			stream.respond({':status': 202});
 			stream.end();
 		}
 	});
 
 	await promisify(server.listen.bind(server))(0);
-	const { port } = server.address();
+	const {port} = server.address();
 
 	const result = await waitForLocalhost({
 		port,
@@ -124,18 +124,18 @@ test("should handle HTTP/2-only server with custom status codes", async (t) => {
 	server.close();
 });
 
-test("should handle HTTP/2-only server with GET method", async (t) => {
+test('should handle HTTP/2-only server with GET method', async t => {
 	const server = http2.createServer();
 
-	server.on("stream", (stream, headers) => {
-		if (headers[":method"] === "GET") {
-			stream.respond({ ":status": 200 });
-			stream.end("OK");
+	server.on('stream', (stream, headers) => {
+		if (headers[':method'] === 'GET') {
+			stream.respond({':status': 200});
+			stream.end('OK');
 		}
 	});
 
 	await promisify(server.listen.bind(server))(0);
-	const { port } = server.address();
+	const {port} = server.address();
 
 	const result = await waitForLocalhost({
 		port,
@@ -146,29 +146,29 @@ test("should handle HTTP/2-only server with GET method", async (t) => {
 	server.close();
 });
 
-test("should handle HTTP/2-only server with custom path", async (t) => {
+test('should handle HTTP/2-only server with custom path', async t => {
 	const server = http2.createServer();
 
-	server.on("stream", (stream, headers) => {
-		if (headers[":path"] === "/health" && headers[":method"] === "HEAD") {
-			stream.respond({ ":status": 200 });
+	server.on('stream', (stream, headers) => {
+		if (headers[':path'] === '/health' && headers[':method'] === 'HEAD') {
+			stream.respond({':status': 200});
 			stream.end();
 		}
 	});
 
 	await promisify(server.listen.bind(server))(0);
-	const { port } = server.address();
+	const {port} = server.address();
 
 	const result = await waitForLocalhost({
 		port,
-		path: "/health",
+		path: '/health',
 	});
 	t.truthy(result);
 
 	server.close();
 });
 
-test("should support AbortSignal.timeout()", async (t) => {
+test('should support AbortSignal.timeout()', async t => {
 	const startTime = Date.now();
 
 	try {
@@ -176,26 +176,26 @@ test("should support AbortSignal.timeout()", async (t) => {
 			port: 9999, // Non-existent server
 			signal: AbortSignal.timeout(500),
 		});
-		t.fail("Should have timed out");
+		t.fail('Should have timed out');
 	} catch (error) {
 		const elapsed = Date.now() - startTime;
-		t.true(elapsed >= 500, "Should timeout after 500ms");
-		t.true(elapsed < 700, "Should timeout close to 500ms");
-		t.is(error.name, "TimeoutError");
+		t.true(elapsed >= 500, 'Should timeout after 500ms');
+		t.true(elapsed < 700, 'Should timeout close to 500ms');
+		t.is(error.name, 'TimeoutError');
 	}
 });
 
-test("should not loop on error", async (t) => {
+test('should not loop on error', async t => {
 	t.timeout(40_000);
 	try {
 		await waitForLocalhost({
 			port: 5879,
 			signal: AbortSignal.timeout(30_000),
-			path: "/json/list",
+			path: '/json/list',
 			useGet: true,
 		});
-		t.fail("should have timeout out");
+		t.fail('should have timeout out');
 	} catch (error) {
-		t.is(error.name, "TimeoutError");
+		t.is(error.name, 'TimeoutError');
 	}
 });

--- a/test.js
+++ b/test.js
@@ -1,32 +1,32 @@
-import {promisify} from 'node:util';
-import http2 from 'node:http2';
-import test from 'ava';
-import delay from 'delay';
-import createTestServer from 'create-test-server';
-import waitForLocalhost from './index.js';
+import { promisify } from "node:util";
+import http2 from "node:http2";
+import test from "ava";
+import delay from "delay";
+import createTestServer from "create-test-server";
+import waitForLocalhost from "./index.js";
 
-test('main', async t => {
+test("main", async (t) => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.head('/', async (request, response) => {
+	server.head("/", async (request, response) => {
 		await delay(1000);
 		response.end();
 		t.pass();
 	});
 
-	await waitForLocalhost({port: server.port});
+	await waitForLocalhost({ port: server.port });
 
 	t.pass();
 
 	await server.close();
 });
 
-test('use get method', async t => {
+test("use get method", async (t) => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.get('/', async (request, response) => {
+	server.get("/", async (request, response) => {
 		await delay(1000);
 		response.end();
 		t.pass();
@@ -42,11 +42,11 @@ test('use get method', async t => {
 	await server.close();
 });
 
-test('use custom path', async t => {
+test("use custom path", async (t) => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.get('/health', async (request, response) => {
+	server.get("/health", async (request, response) => {
 		await delay(1000);
 		response.end();
 		t.pass();
@@ -54,7 +54,7 @@ test('use custom path', async t => {
 
 	await waitForLocalhost({
 		port: server.port,
-		path: '/health',
+		path: "/health",
 	});
 
 	t.pass();
@@ -62,11 +62,11 @@ test('use custom path', async t => {
 	await server.close();
 });
 
-test('use custom statusCodes', async t => {
+test("use custom statusCodes", async (t) => {
 	t.plan(2);
 
 	const server = await createTestServer();
-	server.get('/', async (request, response) => {
+	server.get("/", async (request, response) => {
 		await delay(1000);
 		response.status(202).end();
 		t.pass();
@@ -82,38 +82,38 @@ test('use custom statusCodes', async t => {
 	await server.close();
 });
 
-test('should handle HTTP/2-only server with fallback', async t => {
+test("should handle HTTP/2-only server with fallback", async (t) => {
 	const server = http2.createServer();
 
-	server.on('stream', (stream, headers) => {
-		if (headers[':method'] === 'HEAD') {
-			stream.respond({':status': 200});
+	server.on("stream", (stream, headers) => {
+		if (headers[":method"] === "HEAD") {
+			stream.respond({ ":status": 200 });
 			stream.end();
 		}
 	});
 
 	await promisify(server.listen.bind(server))(0);
-	const {port} = server.address();
+	const { port } = server.address();
 
-	const result = await waitForLocalhost({port});
+	const result = await waitForLocalhost({ port });
 	t.truthy(result);
 	t.true([4, 6].includes(result.ipVersion));
 
 	server.close();
 });
 
-test('should handle HTTP/2-only server with custom status codes', async t => {
+test("should handle HTTP/2-only server with custom status codes", async (t) => {
 	const server = http2.createServer();
 
-	server.on('stream', (stream, headers) => {
-		if (headers[':method'] === 'HEAD') {
-			stream.respond({':status': 202});
+	server.on("stream", (stream, headers) => {
+		if (headers[":method"] === "HEAD") {
+			stream.respond({ ":status": 202 });
 			stream.end();
 		}
 	});
 
 	await promisify(server.listen.bind(server))(0);
-	const {port} = server.address();
+	const { port } = server.address();
 
 	const result = await waitForLocalhost({
 		port,
@@ -124,18 +124,18 @@ test('should handle HTTP/2-only server with custom status codes', async t => {
 	server.close();
 });
 
-test('should handle HTTP/2-only server with GET method', async t => {
+test("should handle HTTP/2-only server with GET method", async (t) => {
 	const server = http2.createServer();
 
-	server.on('stream', (stream, headers) => {
-		if (headers[':method'] === 'GET') {
-			stream.respond({':status': 200});
-			stream.end('OK');
+	server.on("stream", (stream, headers) => {
+		if (headers[":method"] === "GET") {
+			stream.respond({ ":status": 200 });
+			stream.end("OK");
 		}
 	});
 
 	await promisify(server.listen.bind(server))(0);
-	const {port} = server.address();
+	const { port } = server.address();
 
 	const result = await waitForLocalhost({
 		port,
@@ -146,29 +146,29 @@ test('should handle HTTP/2-only server with GET method', async t => {
 	server.close();
 });
 
-test('should handle HTTP/2-only server with custom path', async t => {
+test("should handle HTTP/2-only server with custom path", async (t) => {
 	const server = http2.createServer();
 
-	server.on('stream', (stream, headers) => {
-		if (headers[':path'] === '/health' && headers[':method'] === 'HEAD') {
-			stream.respond({':status': 200});
+	server.on("stream", (stream, headers) => {
+		if (headers[":path"] === "/health" && headers[":method"] === "HEAD") {
+			stream.respond({ ":status": 200 });
 			stream.end();
 		}
 	});
 
 	await promisify(server.listen.bind(server))(0);
-	const {port} = server.address();
+	const { port } = server.address();
 
 	const result = await waitForLocalhost({
 		port,
-		path: '/health',
+		path: "/health",
 	});
 	t.truthy(result);
 
 	server.close();
 });
 
-test('should support AbortSignal.timeout()', async t => {
+test("should support AbortSignal.timeout()", async (t) => {
 	const startTime = Date.now();
 
 	try {
@@ -176,11 +176,25 @@ test('should support AbortSignal.timeout()', async t => {
 			port: 9999, // Non-existent server
 			signal: AbortSignal.timeout(500),
 		});
-		t.fail('Should have timed out');
+		t.fail("Should have timed out");
 	} catch (error) {
 		const elapsed = Date.now() - startTime;
-		t.true(elapsed >= 500, 'Should timeout after 500ms');
-		t.true(elapsed < 700, 'Should timeout close to 500ms');
-		t.is(error.name, 'TimeoutError');
+		t.true(elapsed >= 500, "Should timeout after 500ms");
+		t.true(elapsed < 700, "Should timeout close to 500ms");
+		t.is(error.name, "TimeoutError");
+	}
+});
+
+test("should not loop on error", async (t) => {
+	try {
+		await waitForLocalhost({
+			port: 5879,
+			signal: AbortSignal.timeout(30_000),
+			path: "/json/list",
+			useGet: true,
+		});
+		t.fail("should have timeout out");
+	} catch (error) {
+		t.is(error.name, "TimeoutError");
 	}
 });


### PR DESCRIPTION
fixes #19 

This removes all event listeners on cleanup, so that the cleanup function is called once at most and no endless loop can occur.